### PR TITLE
Fix issue with leb128

### DIFF
--- a/src/obu.rs
+++ b/src/obu.rs
@@ -551,8 +551,7 @@ pub fn leb128<R: io::Read>(bs: &mut R) -> io::Result<(u32, u32)> {
             break;
         }
     }
-    debug_assert!(value < (1u64 << 32));
-    if value < (1u64 << 32) {
+    if value > (1u64 << 32) - 1 {
         return Err(std::io::Error::new(
             io::ErrorKind::InvalidData,
             "leb128() value is too large to fit in u32",


### PR DESCRIPTION
Previous PR added an error instead of an assert when there are invalid values in the leb128 function, but the error is thrown when the value is lower, but it was supposed to throw when it was higher.

I also removed the debug assert, as the error is propagated anyway, so no reason to keep the assert?